### PR TITLE
Enable IPO/LTO

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,12 @@ elif [[ ${CXXFLAGS} == *"-std="* ]]; then
     exit 1
 fi
 
+# IPO/LTO does only work with certain toolchains
+WarpX_IPO=ON
+if [[ ${target_platform} =~ osx.* ]]; then
+    WarpX_IPO=OFF
+fi
+
 for dim in "2" "3" "RZ"
 do
     cmake \
@@ -24,6 +30,7 @@ do
         -DCMAKE_INSTALL_LIBDIR=lib            \
         -DCMAKE_INSTALL_PREFIX=${PREFIX}      \
         -DWarpX_openpmd_internal=OFF          \
+        -DWarpX_IPO=${WarpX_IPO}              \
         -DWarpX_ASCENT=OFF  \
         -DWarpX_LIB=ON      \
         -DWarpX_MPI=OFF     \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "warpx" %}
 {% set version = "21.04" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set sha256 = "51d2d8b4542eada96216e8b128c0545c4b7527addc2038efebe586c32c4020a0" %}
 
 package:


### PR DESCRIPTION
Enable IPO/LTO to reduce binary size (Linux).

- [x] `Clang 11.1.0 with MSVC-like command-line`: not available
- [x] macOS `Clang 11.1.0`: not available

Refs.:
- https://github.com/AMReX-Codes/amrex/pull/1890
- https://github.com/ECP-WarpX/WarpX/pull/1822

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
