### PR TITLE
Windows: Disable OpenMP

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,12 +10,9 @@ for %%d in (2 3 RZ) do (
         -S . -B build                         ^
         -G "Ninja"                            ^
         -DCMAKE_BUILD_TYPE=RelWithDebInfo     ^
-        -DCMAKE_C_COMPILER=clang-cl           ^
-        -DCMAKE_CXX_COMPILER=clang-cl         ^
-        -DCMAKE_LINKER=lld-link               ^
-        -DCMAKE_NM=llvm-nm                    ^
         -DCMAKE_VERBOSE_MAKEFILE=ON           ^
         -DWarpX_ASCENT=OFF  ^
+        -DWarpX_COMPUTE=NOACC ^
         -DWarpX_LIB=ON      ^
         -DWarpX_MPI=OFF     ^
         -DWarpX_OPENPMD=ON  ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "warpx" %}
 {% set version = "21.10" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set sha256 = "d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454" %}
 
 package:
@@ -22,15 +22,13 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - ccache        # [unix]
-    - clang         # [win]
-    - lld           # [win]
     # TODO: add libxml2 dep in lld-feedstock
     - libxml2       # [win]
     - make          # [unix]
     - ninja         # [win]
     - cmake >=3.15.0
     - libgomp       # [linux]
-    - llvm-openmp   # [osx or win]
+    - llvm-openmp   # [osx]
   host:
     - blaspp
     - boost-cpp


### PR DESCRIPTION
The OpenMP implementation of most of the Conda-Forge software stack is using MSVC's OpenMP runtime (limited to OpenMP 2.0). This is also what is used in blosc in our dependencies.

When we compile WarpX, we need a newer OpenMP (4.0+), which is why we compiled with LLVM. Unfortunately, the LLVM OpenMP runtime and MSVC runtime cannot be loaded at the same time and thus crash if we perform I/O operations.

For now, we just disable OpenMP for WarpX builds. In the future, Microsoft might upgrade their OpenMP runtime:
https://devblogs.microsoft.com/cppblog/improved-openmp-support-for-cpp-in-visual-studio/

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
