### PR TITLE
Win: Fix .dll lib path

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -28,16 +28,16 @@ for %%d in (1 2 3 RZ) do (
     cmake --build build --config RelWithDebInfo --parallel 2
     if errorlevel 1 exit 1
 
-    for /r "build\bin" %%f in (*.exe) do (
+    for /r "build\bin" %%f in (warpx*.exe) do (
         echo %%~nf
         dir
         copy build\bin\%%~nf.exe %LIBRARY_PREFIX%\bin\
         if errorlevel 1 exit 1
     )
-    for /r "build\lib" %%f in (*.dll) do (
+    for /r "build\lib" %%f in (libwarpx*.dll) do (
         echo %%~nf
         dir
-        copy build\lib\%%~nf.dll %LIBRARY_PREFIX%\lib\
+        copy build\lib\%%~nf.dll %LIBRARY_PREFIX%\bin\
         if errorlevel 1 exit 1
     )
     
@@ -48,5 +48,5 @@ for %%d in (1 2 3 RZ) do (
 ::  if errorlevel 1 exit 1
 
 :: add Python API (PICMI interface)
-set "PYWARPX_LIB_DIR=%LIBRARY_PREFIX%\lib"
+set "PYWARPX_LIB_DIR=%LIBRARY_PREFIX%\bin"
 %PYTHON% -m pip install . -vv --no-build-isolation

--- a/recipe/test.bat
+++ b/recipe/test.bat
@@ -19,6 +19,8 @@ if errorlevel 1 exit 1
 warpx.RZ.NOMPI.OMP.DP.OPMD.PSATD.QED.exe %TEST_DIR%\inputs_rz max_step=50 diag1.intervals=10 diag1.format=openpmd
 if errorlevel 1 exit 1
 
+dumpbin /imports %PREFIX%\Library\bin\libwarpx*.dll | find /i ".dll"
+
 :: Python: 3D
 %PYTHON% %TEST_DIR%\PICMI_inputs_3d.py
 if errorlevel 1 exit 1


### PR DESCRIPTION
Move every `.dll` to `bin/`, where `PATH` can find it.
Ref.: https://github.com/conda-forge/warpx-feedstock/pull/38#issuecomment-1015613012

Related to first issue in #37

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
