### PR TITLE
CMake: Keep `CMAKE_ARGS`

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,15 +5,10 @@
 if not exist %LIBRARY_PREFIX%\bin md %LIBRARY_PREFIX%\bin
 if errorlevel 1 exit 1
 
-:: <=22.07 work-around for
-:: https://github.com/AMReX-Codes/amrex/pull/2807
-echo "CXXFLAGS: %CXXFLAGS%"
-set "CXXFLAGS=%CXXFLAGS% /D_USE_MATH_DEFINES"
-echo "CXXFLAGS: %CXXFLAGS%"
-
 for %%d in (1 2 3 RZ) do (
     cmake ^
         -S %SRC_DIR% -B build                 ^
+        %CMAKE_ARGS%                          ^
         -G "Ninja"                            ^
         -DCMAKE_BUILD_TYPE=RelWithDebInfo     ^
         -DCMAKE_C_COMPILER=clang-cl           ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,7 @@ for dim in "1" "2" "3" "RZ"
 do
     cmake \
         -S ${SRC_DIR} -B build                \
+        ${CMAKE_ARGS}                         \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo     \
         -DCMAKE_VERBOSE_MAKEFILE=ON           \
         -DCMAKE_INSTALL_LIBDIR=lib            \


### PR DESCRIPTION
Keep the Conda-Forge set `CMAKE_ARGS` arguments in our CMake calls.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
